### PR TITLE
Add missing geometry attribute

### DIFF
--- a/src/geometry/circlecorridorpolygon.js
+++ b/src/geometry/circlecorridorpolygon.js
@@ -3,6 +3,7 @@ var ms = require("milsymbol");
 module.exports = function(feature) {
   var annotation = {};
   var geometry;
+  annotation.geometry = { type: "Point" };
 
   switch (feature.geometry.type) {
     case "Point":


### PR DESCRIPTION
I'm currently experimenting with milgraphics and noticed an error in the latest commit that prevented me from loading some of the examples.  This pull request adds the missing attribute. You have probably already fixed this in your development version, so feel free to close this pull request. I know that the code is a work in progress and that it will change frequently. 

